### PR TITLE
Fix: "수정 로그인 사용자 개인 포지션 랭킹, 로그인 사용자가 참여하고 있는 팀의 랭킹 조회 API"

### DIFF
--- a/src/main/java/me/coldrain/ninetyminute/controller/MemberController.java
+++ b/src/main/java/me/coldrain/ninetyminute/controller/MemberController.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import me.coldrain.ninetyminute.dto.request.*;
 import me.coldrain.ninetyminute.service.KakaoMemberService;
 import me.coldrain.ninetyminute.service.MemberService;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/main/java/me/coldrain/ninetyminute/controller/RankController.java
+++ b/src/main/java/me/coldrain/ninetyminute/controller/RankController.java
@@ -1,8 +1,10 @@
 package me.coldrain.ninetyminute.controller;
 
 import lombok.RequiredArgsConstructor;
+import me.coldrain.ninetyminute.security.UserDetailsImpl;
 import me.coldrain.ninetyminute.service.RankService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -26,14 +28,14 @@ public class RankController {
     }
 
     //로그인 사용자 개인 랭킹
-    @GetMapping("/api/home/rank/members/{member_id}")
-    public ResponseEntity<?> myRankGet(@PathVariable Long member_id) {
-        return rankService.myRankGet(member_id);
+    @GetMapping("/api/home/rank/members/myranking")
+    public ResponseEntity<?> myRankGet(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return rankService.myRankGet(userDetails);
     }
 
     //로그인 사용자가 참여하고 있는 팀의 랭킹 조회
-    @GetMapping("/api/home/rank/members/{member_id}/teams")
-    public ResponseEntity<?> myTeamRankGet(@PathVariable Long member_id) {
-        return rankService.myTeamRankGet(member_id);
+    @GetMapping("/api/home/rank/members/myranking/teams")
+    public ResponseEntity<?> myTeamRankGet(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return rankService.myTeamRankGet(userDetails);
     }
 }

--- a/src/main/java/me/coldrain/ninetyminute/dto/response/MyRankResponse.java
+++ b/src/main/java/me/coldrain/ninetyminute/dto/response/MyRankResponse.java
@@ -1,10 +1,10 @@
 package me.coldrain.ninetyminute.dto.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @Setter
 public class MyRankResponse {

--- a/src/main/java/me/coldrain/ninetyminute/dto/response/MyTeamRankResponse.java
+++ b/src/main/java/me/coldrain/ninetyminute/dto/response/MyTeamRankResponse.java
@@ -1,16 +1,40 @@
 package me.coldrain.ninetyminute.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@AllArgsConstructor
+import java.util.List;
+
+@NoArgsConstructor
 @Getter
 @Setter
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class MyTeamRankResponse {
-    private Long teamId;
-    private String mainArea;
-    private String teamName;
-    private int winPoint;
-    private int myTeamRank;
+    private teamCaptain teamCaptain;
+    private List<teamMember> teamMember;
+
+    @NoArgsConstructor
+    @Setter
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    public static class teamCaptain{
+        private Long teamId;
+        private String mainArea;
+        private String teamName;
+        private int winPoint;
+        private int myOpenTeamRank;
+    }
+
+    @NoArgsConstructor
+    @Setter
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    public static class teamMember{
+        private Long teamId;
+        private String mainArea;
+        private String teamName;
+        private int winPoint;
+        private int myTeamRank;
+    }
 }

--- a/src/main/java/me/coldrain/ninetyminute/repository/AbilityRepository.java
+++ b/src/main/java/me/coldrain/ninetyminute/repository/AbilityRepository.java
@@ -8,10 +8,6 @@ import java.util.List;
 public interface AbilityRepository extends JpaRepository<Ability, Long> {
 
     //개별 랭킹 확인을 위한 포지션별 랭킹 전체 조회
-    List<Ability> findAllByOrderByMvpPointDesc();
-
-    List<Ability> findAllByOrderByCharmingPointDesc();
-
     List<Ability> findAllByOrderByStrikerPointDesc();
 
     List<Ability> findAllByOrderByMidfielderPointDesc();


### PR DESCRIPTION
- 팀,개인포지션 랭킹과 같은 순위 알고리즘을 적용

- 로그인 사용자가 참여하고 있는 팀의 랭킹의 경우
      1순위 정렬 승점
      2순위 정렬 승률
      위 2개가 모두 같은 경우 동일 랭킹으로 표시

-  로그인 사용자 개인 포지션 랭킹의 경우
      로그인 사용자의 포지션 포인트 값으로 정렬
      해당 값이 같으면 동일 랭킹으로 표시