### PR TITLE
Fix: "수정 팀 정보 조회 API"

### DIFF
--- a/src/main/java/me/coldrain/ninetyminute/dto/response/TeamInfoResponse.java
+++ b/src/main/java/me/coldrain/ninetyminute/dto/response/TeamInfoResponse.java
@@ -32,6 +32,7 @@ public class TeamInfoResponse {
     private int headCount;
     private boolean teamCaptain;
     private boolean otherCaptain;
+    private boolean approved;
     private boolean participate;
     private RecentMatchHistory recentMatchHistory;
     private LocalDateTime createdDate;

--- a/src/main/java/me/coldrain/ninetyminute/service/TeamService.java
+++ b/src/main/java/me/coldrain/ninetyminute/service/TeamService.java
@@ -117,9 +117,10 @@ public class TeamService {
 
         boolean teamCaptain = false;
         boolean otherCaptain = false;
+        boolean approved = false;
         boolean participate = false;
 
-        if (userDetails.getUser().getOpenTeam().getId() != null) {
+        if (userDetails.getUser().getOpenTeam() != null) {
             if (teamId.equals(userDetails.getUser().getOpenTeam().getId())) {
                 teamCaptain = true;
             } else {
@@ -127,8 +128,13 @@ public class TeamService {
             }
         }
 
-        Optional<Participation> teamMember = participationRepository.findByMemberIdAndTeamIdTrue(userDetails.getUser().getId(), teamId);
-        if (teamMember.isPresent()) {
+        Optional<Participation> approvedTeamMember = participationRepository.findByMemberIdAndTeamIdTrue(userDetails.getUser().getId(), teamId);
+        if (approvedTeamMember.isPresent()) {
+            approved = true;
+        }
+
+        Optional<Participation> participateTeam = participationRepository.findByTeamIdAndMemberId(teamId, userDetails.getUser().getId());
+        if (participateTeam.isPresent()) {
             participate = true;
         }
 
@@ -178,6 +184,7 @@ public class TeamService {
                 headCount,
                 teamCaptain,
                 otherCaptain,
+                approved,
                 participate,
                 recentMatchHistory,
                 infoTeam.getCreatedDate(),


### PR DESCRIPTION
- 개설한 팀 유무를 확인하는 로직에서 발생하는 오류 수정
- 기존 변수 변경 및 신규 변수 추가

   변경 : 해당 팀 참여여부 변수
   ㄴparticipate -> approved

   추가 : 해당 팀 참여신청 여부 변수
   ㄴparticipate