### PR TITLE
Fix: "수정, 회원정보 조회 API, 회원 참여한 경기 히스토리 조회"

### DIFF
--- a/src/main/java/me/coldrain/ninetyminute/repository/ApplyRepository.java
+++ b/src/main/java/me/coldrain/ninetyminute/repository/ApplyRepository.java
@@ -15,8 +15,11 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
     @Query("SELECT a FROM Apply a WHERE a.applyTeam.id = :applyTeamId AND a.team.id = :teamId AND a.approved = true")
     Optional<Apply> findByApplyTeamIdAndTeamIdTrue(final Long applyTeamId, final Long teamId);
 
-//    @Query("select a from Apply a where a.team.id =: teamId order by a.createdDate desc ")
-//    List<Apply> findAllByTeamId(final Long teamId);
+    @Query("select a from Apply a where a.team.id = :teamId AND a.approved = true  AND a.endMatchStatus = true  AND  a.opposingTeamEndMatchStatus = true")
+    List<Apply> findAllByApplyEndTeamId(final Long teamId);
+
+    @Query("select a from Apply a where a.applyTeam.id = :ApplyTeamId AND a.approved = true  AND a.endMatchStatus = true  AND  a.opposingTeamEndMatchStatus = true")
+    List<Apply> findAllByApplyEndApplyTeamId(final Long ApplyTeamId);
 
     @Query("select a from Apply a where a.team.id = :teamId order by a.createdDate desc ")
     List<Apply> findAllByTeamIdOrderByCreatedDate(final Long teamId);

--- a/src/main/java/me/coldrain/ninetyminute/repository/HistoryRepository.java
+++ b/src/main/java/me/coldrain/ninetyminute/repository/HistoryRepository.java
@@ -20,8 +20,8 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
     @Query("select h from History h where h.beforeMatching.id = :beforeMatchingId and h.afterMatching.id = :afterMatchingId")
     Optional<History> findByBeforeMatchingIdAndAfterMatchingId(final Long beforeMatchingId, final Long afterMatchingId);
     
-    @Query("select h from History h where h.afterMatching.id = :afterMatching")
-    Optional<History> findByMemberGameHistory(Long afterMatching);
+    @Query("select h from History h where h.beforeMatching.id = :beforeMatching")
+    Optional<History> findByMemberGameHistory(Long beforeMatching);
 
     @Query("select h from History h where h.id = :historyId")
     List<History> findAllByHistoryId(Long historyId);

--- a/src/main/java/me/coldrain/ninetyminute/service/MemberInfoService.java
+++ b/src/main/java/me/coldrain/ninetyminute/service/MemberInfoService.java
@@ -28,53 +28,57 @@ public class MemberInfoService {
     private final SubstituteRepository substituteRepository;
     private final HistoryRepository historyRepository;
     private final AfterMatchingRepository afterMatchingRepository;
+    private final ApplyRepository applyRepository;
 
     //회원정보 조회
     public ResponseEntity<?> memberInfoGet(Long memberId, UserDetailsImpl userDetails) {
-        try {
-            Member member = memberRepository.findById(memberId).orElseThrow();
 
-            if (memberService.secessionMemberCheck(member.getUsername())) {
-                return new ResponseEntity<>("탈퇴 처리된 회원 입니다.", HttpStatus.BAD_REQUEST);
-            }
+        Member member = memberRepository.findById(memberId).orElse(null);
+        if (member == null) {
+            return new ResponseEntity<>("존재하지 않는 회원입니다.", HttpStatus.BAD_REQUEST);
+        }
 
-            boolean myInfo = memberId.equals(userDetails.getUser().getId());
+        if (memberService.secessionMemberCheck(member.getUsername())) {
+            return new ResponseEntity<>("탈퇴 처리된 회원 입니다.", HttpStatus.BAD_REQUEST);
+        }
 
-            List<Participation> myTeam = participationRepository.findAllByMemberIdTrue(member.getId());
+        boolean myInfo = memberId.equals(userDetails.getUser().getId());
 
-            int totalMyTeamWinCount = 0;
+        List<Participation> myTeam = participationRepository.findAllByMemberIdTrue(member.getId());
+
+        int totalMyTeamWinCount = 0;
+        int totalMyTeamGameCount = 0;
+
+        if (myTeam.size() != 0) {
             for (int i = 0; i < myTeam.size(); i++) {
                 List<AfterMatching> winMyTeamHistory
                         = afterMatchingRepository.findAllByWinHistory(myTeam.get(i).getTeam().getName());
                 totalMyTeamWinCount = totalMyTeamWinCount + winMyTeamHistory.size();
             }
 
-            int totalMyTeamGameCount = 0;
             for (int i = 0; i < myTeam.size(); i++) {
-                List<History> myTeamHistory
-                        = historyRepository.findAllByHistoryId(myTeam.get(i).getTeam().getHistory().getId());
-                totalMyTeamGameCount = myTeamHistory.size();
+                List<Apply> applyEndTeamCount = applyRepository.findAllByApplyEndTeamId(myTeam.get(i).getTeam().getId());
+                List<Apply> applyEndApplyTeamCount = applyRepository.findAllByApplyEndApplyTeamId(myTeam.get(i).getTeam().getId());
+                totalMyTeamGameCount = totalMyTeamGameCount + applyEndTeamCount.size() + applyEndApplyTeamCount.size();
             }
-
-            MemberInfoResponse memberInfoResponse = new MemberInfoResponse(
-                    myInfo,
-                    member.getNickname(),
-                    member.getProfileUrl(),
-                    member.getContact(),
-                    member.getPhone(),
-                    member.getPosition(),
-                    member.getAbility().getMvpPoint(),
-                    totalMyTeamWinCount,
-                    totalMyTeamGameCount,
-                    member.getAbility().getStrikerPoint(),
-                    member.getAbility().getMidfielderPoint(),
-                    member.getAbility().getDefenderPoint(),
-                    member.getAbility().getGoalkeeperPoint(),
-                    member.getAbility().getCharmingPoint());
-            return new ResponseEntity<>(memberInfoResponse, HttpStatus.OK);
-        } catch (Exception e) {
-            return new ResponseEntity<>("존재하지 않는 회원입니다.", HttpStatus.BAD_REQUEST);
         }
+
+        MemberInfoResponse memberInfoResponse = new MemberInfoResponse(
+                myInfo,
+                member.getNickname(),
+                member.getProfileUrl(),
+                member.getContact(),
+                member.getPhone(),
+                member.getPosition(),
+                member.getAbility().getMvpPoint(),
+                totalMyTeamWinCount,
+                totalMyTeamGameCount,
+                member.getAbility().getStrikerPoint(),
+                member.getAbility().getMidfielderPoint(),
+                member.getAbility().getDefenderPoint(),
+                member.getAbility().getGoalkeeperPoint(),
+                member.getAbility().getCharmingPoint());
+        return new ResponseEntity<>(memberInfoResponse, HttpStatus.OK);
     }
 
     //참여 신청중인 팀 신청취소
@@ -100,44 +104,41 @@ public class MemberInfoService {
         MemberGameHistoryResponse.Team memberTeamGameHistoryResponse = new MemberGameHistoryResponse.Team();
         MemberGameHistoryResponse.OpposingTeam memberOpposingTeamGameHistoryResponse = new MemberGameHistoryResponse.OpposingTeam();
 
-        try {
-            Member member = memberRepository.findById(memberId).orElseThrow();
+        Member member = memberRepository.findById(memberId).orElse(null);
+        if (member == null) {
+            return new ResponseEntity<>("존재하지 않는 회원입니다.", HttpStatus.BAD_REQUEST);
+        }
 
-            if (memberService.secessionMemberCheck(member.getUsername())) {
-                return new ResponseEntity<>("탈퇴 처리된 회원 입니다.", HttpStatus.BAD_REQUEST);
-            }
+        if (memberService.secessionMemberCheck(member.getUsername())) {
+            return new ResponseEntity<>("탈퇴 처리된 회원 입니다.", HttpStatus.BAD_REQUEST);
+        }
 
-            boolean myHistory = memberId.equals(userDetails.getUser().getId());
+        boolean myHistory = memberId.equals(userDetails.getUser().getId());
 
-            List<FieldMember> gameFieldMemberList = fieldMemberRepository.findAllByGameFieldMembers(memberId);
+        List<FieldMember> gameFieldMemberList = fieldMemberRepository.findAllByGameFieldMembers(memberId);
+        if (gameFieldMemberList.size() != 0) {
             for (int i = 0; i < gameFieldMemberList.size(); i++) {
-                History FieldMemberHistory = historyRepository.findByMemberGameHistory
-                        (gameFieldMemberList.get(i).getAfterMatching().getId()).orElseThrow();
+                History FieldMemberHistory = historyRepository.findByMemberGameHistory(gameFieldMemberList.get(i).getBeforeMatching().getId()).orElseThrow();
                 memberGameHistoryResponse.setMyHistory(myHistory);
                 memberGameHistoryResponse.setHistoryId(FieldMemberHistory.getId());
-                memberGameHistoryResponse.setMatchDate
-                        (gameFieldMemberList.get(i).getBeforeMatching().getMatchDate());
+                memberGameHistoryResponse.setMatchDate(gameFieldMemberList.get(i).getBeforeMatching().getMatchDate());
 
-                memberTeamGameHistoryResponse.setName
-                        (gameFieldMemberList.get(i).getBeforeMatching().getTeamName());
-                memberTeamGameHistoryResponse.setRecord
-                        (gameFieldMemberList.get(i).getAfterMatching().getResult());
-                memberTeamGameHistoryResponse.setScore
-                        (gameFieldMemberList.get(i).getAfterMatching().getScore());
+                memberTeamGameHistoryResponse.setName(gameFieldMemberList.get(i).getBeforeMatching().getTeamName());
+                memberTeamGameHistoryResponse.setRecord(gameFieldMemberList.get(i).getAfterMatching().getResult());
+                memberTeamGameHistoryResponse.setScore(gameFieldMemberList.get(i).getAfterMatching().getScore());
                 memberGameHistoryResponse.setTeam(memberTeamGameHistoryResponse);
 
-                memberOpposingTeamGameHistoryResponse.setName
-                        (gameFieldMemberList.get(i).getBeforeMatching().getOpposingTeamName());
-                memberOpposingTeamGameHistoryResponse.setRecord
-                        (gameFieldMemberList.get(i).getAfterMatching().getOpponentResult());
-                memberOpposingTeamGameHistoryResponse.setScore
-                        (gameFieldMemberList.get(i).getAfterMatching().getOpponentScore());
+                memberOpposingTeamGameHistoryResponse.setName(gameFieldMemberList.get(i).getBeforeMatching().getOpposingTeamName());
+                memberOpposingTeamGameHistoryResponse.setRecord(gameFieldMemberList.get(i).getAfterMatching().getOpponentResult());
+                memberOpposingTeamGameHistoryResponse.setScore(gameFieldMemberList.get(i).getAfterMatching().getOpponentScore());
                 memberGameHistoryResponse.setOpposingTeam(memberOpposingTeamGameHistoryResponse);
 
                 memberGameHistoryResponseList.add(memberGameHistoryResponse);
             }
+        }
 
-            List<SubstituteMember> gameSubstituteMemberList = substituteRepository.findAllByGameSubstituteMembers(memberId);
+        List<SubstituteMember> gameSubstituteMemberList = substituteRepository.findAllByGameSubstituteMembers(memberId);
+        if (gameSubstituteMemberList.size() != 0) {
             for (int i = 0; i < gameSubstituteMemberList.size(); i++) {
                 History SubstituteMemberHistory = historyRepository.findByMemberGameHistory
                         (gameSubstituteMemberList.get(i).getAfterMatching().getId()).orElseThrow();
@@ -164,8 +165,6 @@ public class MemberInfoService {
 
                 memberGameHistoryResponseList.add(memberGameHistoryResponse);
             }
-        } catch (Exception e) {
-            return new ResponseEntity<>("존재하지 않는 회원입니다.", HttpStatus.BAD_REQUEST);
         }
         return new ResponseEntity<>(memberGameHistoryResponseList, HttpStatus.OK);
     }


### PR DESCRIPTION
1. 회원정보 조회
- 정상적인 memberId여도 '존재하지 않는 회원입니다' 응답값으로 나오던 오류 수정
   ㄴ이유 : 회원의 전적 계산을 위해 회원이 참여한 팀의 히스토리ID를 불러와서 참조했는데 팀은 여러개의 히스토리ID 가질 수 있기 때문에 익셉션이 터지면서 기존의 회원정보조회 자체를 try-catch문으로 감싸놔서 나오던 문제

2. 회원 참여한 경기 히스토리 조회
- 정상적인 memberId여도 '존재하지 않는 회원입니다' 응답값으로 나오던 오류 수정
   ㄴ회원정보 조회와 비슷한데 try-catch문으로 감싸놔서 생기던 문제로 이 API는 DB상에 조회하던 데이터에 참조한던 부분(aftermatching)에 null이 들어가서 생기던 문제 데이터 수정으로 해결