### PR TITLE
Fix: "수정 팀 정보 조회 API"

### DIFF
--- a/src/main/java/me/coldrain/ninetyminute/repository/BeforeMatchingRepository.java
+++ b/src/main/java/me/coldrain/ninetyminute/repository/BeforeMatchingRepository.java
@@ -15,7 +15,10 @@ public interface BeforeMatchingRepository extends JpaRepository<BeforeMatching, 
     List<BeforeMatching> findAllByBeforeMatching(final Long teamId);
 
     @Query("select bm from BeforeMatching bm where bm.apply.team.id = :teamId and bm.apply.approved = true order by bm.createdDate desc")
-    Optional<BeforeMatching> findByRecentBeforeMatching(Long teamId);
+    Optional<BeforeMatching> findByRecentTeamBeforeMatching(Long teamId);
+
+    @Query("select bm from BeforeMatching bm where bm.apply.applyTeam.id = :teamId and bm.apply.approved = true order by bm.createdDate desc")
+    Optional<BeforeMatching> findByRecentOpposingTeamBeforeMatching(Long teamId);
 
     @Query("select bm from BeforeMatching bm where bm.apply.id = :applyId")
     Optional<BeforeMatching> findByApplyId(final Long applyId);

--- a/src/main/java/me/coldrain/ninetyminute/service/TeamService.java
+++ b/src/main/java/me/coldrain/ninetyminute/service/TeamService.java
@@ -149,9 +149,18 @@ public class TeamService {
 
         TeamInfoResponse.RecentMatchHistory recentMatchHistory = new TeamInfoResponse.RecentMatchHistory();
         Team teamHistoryCheck = teamRepository.findById(teamId).orElseThrow();
+        BeforeMatching recentBeforeMatching;
         if (teamHistoryCheck.getHistory() != null) {
-            BeforeMatching recentTeamBeforeMatching = beforeMatchingRepository.findByRecentBeforeMatching(teamId).orElseThrow();
-            History recentHistory = historyRepository.findByRecentHistory(recentTeamBeforeMatching.getId()).orElseThrow();
+            BeforeMatching recentTeamBeforeMatching = beforeMatchingRepository.findByRecentTeamBeforeMatching(teamId).orElseThrow();
+            BeforeMatching recentOpposingTeamBeforeMatching = beforeMatchingRepository.findByRecentOpposingTeamBeforeMatching(teamId).orElseThrow();
+
+            if (recentTeamBeforeMatching.getMatchDate().after(recentOpposingTeamBeforeMatching.getMatchDate())) {
+                recentBeforeMatching = recentTeamBeforeMatching;
+            } else {
+                recentBeforeMatching = recentOpposingTeamBeforeMatching;
+            }
+
+            History recentHistory = historyRepository.findByRecentHistory(recentBeforeMatching.getId()).orElseThrow();
 
             TeamInfoResponse.RecentMatchHistory.Team recentMatchHistoryTeam = new TeamInfoResponse.RecentMatchHistory.Team(
                     recentHistory.getBeforeMatching().getTeamName(),
@@ -166,7 +175,7 @@ public class TeamService {
             );
 
             recentMatchHistory.setHistoryId(recentHistory.getId());
-            recentMatchHistory.setMatchDate(recentTeamBeforeMatching.getMatchDate());
+            recentMatchHistory.setMatchDate(recentBeforeMatching.getMatchDate());
             recentMatchHistory.setTeam(recentMatchHistoryTeam);
             recentMatchHistory.setOpposingTeam(recentMatchHistoryOpposingTeam);
         } else {


### PR DESCRIPTION
- 기존 로직의 경우 최근 경기 히스토리 조회 시 홈팀일 경우만 조회
- 어웨이팀일 경우도 조회
- 이후 해당 히스토리중 날짜를 비교해서 가장 최근 날짜 경기를 출력