### PR TITLE
Fix: "수정 팀 정보 조회 API"

### DIFF
--- a/src/main/java/me/coldrain/ninetyminute/repository/BeforeMatchingRepository.java
+++ b/src/main/java/me/coldrain/ninetyminute/repository/BeforeMatchingRepository.java
@@ -14,10 +14,10 @@ public interface BeforeMatchingRepository extends JpaRepository<BeforeMatching, 
     @Query("select bm from BeforeMatching bm where bm.apply.team.id = :teamId and bm.apply.approved = true and bm.apply.team.deleted = false order by bm.createdDate desc")
     List<BeforeMatching> findAllByBeforeMatching(final Long teamId);
 
-    @Query("select bm from BeforeMatching bm where bm.apply.team.id = :teamId and bm.apply.approved = true order by bm.createdDate desc")
+    @Query("select bm from BeforeMatching bm where bm.apply.team.id = :teamId and bm.apply.approved = true and bm.apply.endMatchStatus = true and bm.apply.opposingTeamEndMatchStatus = true order by bm.createdDate desc")
     List<BeforeMatching> findByRecentTeamBeforeMatching(Long teamId);
 
-    @Query("select bm from BeforeMatching bm where bm.apply.applyTeam.id = :teamId and bm.apply.approved = true order by bm.createdDate desc")
+    @Query("select bm from BeforeMatching bm where bm.apply.applyTeam.id = :teamId and bm.apply.approved = true and bm.apply.endMatchStatus = true and bm.apply.opposingTeamEndMatchStatus = true  order by bm.createdDate desc")
     List<BeforeMatching> findByRecentOpposingTeamBeforeMatching(Long teamId);
 
     @Query("select bm from BeforeMatching bm where bm.apply.team.id = :teamId and bm.apply.approved = true and bm.apply.team.deleted = false order by bm.createdDate desc")

--- a/src/main/java/me/coldrain/ninetyminute/service/TeamService.java
+++ b/src/main/java/me/coldrain/ninetyminute/service/TeamService.java
@@ -180,7 +180,7 @@ public class TeamService {
             );
 
             recentMatchHistory.setHistoryId(recentHistory.getId());
-            recentMatchHistory.setMatchDate(recentTeamBeforeMatching.getMatchDate());
+            recentMatchHistory.setMatchDate(recentBeforeMatching.getMatchDate());
             recentMatchHistory.setTeam(recentMatchHistoryTeam);
             recentMatchHistory.setOpposingTeam(recentMatchHistoryOpposingTeam);
         } else {


### PR DESCRIPTION
- apply에서 approved여부만 검사해서 생기던 오류 수정
   ㄴapproverd만 검사할 경우 대결이 진행중이거나 대결을 하고 결과 입력을 하지 않은 팀들이 있을 경우 such익셉션이 발생