### PR TITLE
Fix: "수정 팀 랭킹 조회 API"

### DIFF
--- a/src/main/java/me/coldrain/ninetyminute/repository/RecordRepository.java
+++ b/src/main/java/me/coldrain/ninetyminute/repository/RecordRepository.java
@@ -2,11 +2,13 @@ package me.coldrain.ninetyminute.repository;
 
 import me.coldrain.ninetyminute.entity.Record;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface RecordRepository extends JpaRepository<Record, Long> {
     List<Record> findAllByOrderByWinPointDesc();
 
+    @Query("select r from Record r inner join Team t on r.id = t.record.id where t.deleted = false order by r.winPoint desc, r.winRate desc")
     List<Record> findAllByOrderByWinPointDescWinRateDesc();
 }


### PR DESCRIPTION
- 팀 soft delete로 인한 null오류 발생
   ㄴ조건 추가로 문제 해결